### PR TITLE
fix link to pypi in notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install -e .
 For installing the latest stable release in PyPi run:
 
 ```bash
-pip install sbti-finance-tool
+pip install wwf-itr
 ```
 
 ## Development

--- a/examples/1_analysis_example.ipynb
+++ b/examples/1_analysis_example.ipynb
@@ -252,7 +252,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install wwf-finance-tool "
+    "%pip install wwf-itr "
    ]
   },
   {

--- a/examples/2_quick_temp_score_calculation.ipynb
+++ b/examples/2_quick_temp_score_calculation.ipynb
@@ -30,7 +30,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install wwf-finance-tool"
+    "%pip install wwf-itr"
    ]
   },
   {

--- a/examples/3_what-if-analysis.ipynb
+++ b/examples/3_what-if-analysis.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install wwf-finance-tool"
+    "%pip install wwf-itr"
    ]
   },
   {

--- a/examples/4_portfolio_aggregations.ipynb
+++ b/examples/4_portfolio_aggregations.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install wwf-finance-tool"
+    "%pip install wwf-itr"
    ]
   },
   {

--- a/examples/4b_portfolio_agg_readymade_TS.ipynb
+++ b/examples/4b_portfolio_agg_readymade_TS.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install wwf-finance-tool"
+    "%pip install wwf-itr"
    ]
   },
   {

--- a/examples/5_reporting.ipynb
+++ b/examples/5_reporting.ipynb
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install wwf-finance-tool"
+    "%pip install wwf-itr"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "WWF-ITR"
-version = "v0.9.0"
+version = "v0.9.1"
 description = "This package helps companies and financial institutions to assess the temperature alignment of current targets, commitments, and investment and lending portfolios, and to use this information to develop targets for official validation by the SBTi.'"
 authors = ["wwf <ekonomi-finans@wwf.se>"]
 license = "MIT"


### PR DESCRIPTION
Quick fix for pip install in the notebooks. Since we changed the name of the package in PyPI we also need to update the install command.