### PR TITLE
chore(temperature-score): replace `.item()` with `.any()`

### DIFF
--- a/ITR/temperature_score.py
+++ b/ITR/temperature_score.py
@@ -790,8 +790,15 @@ class TemperatureScore(PortfolioAggregation):
         for _, group in grouped_data:
             s1s2_score = np.nan # Initailize the s1s2_score to NaN
             s1_s2_results = 1.0 # Initialize the s1_s2_results to 1.0
-            if (group.loc[group['scope'] == EScope.S1,'to_calculate'].item() or
-                group.loc[group['scope'] == EScope.S2, 'to_calculate'].item()
+            
+            # NOTE: using `.item()` will raise a ValueError if the DataFrame has
+            # more than one row for the particular group, which might happens
+            # if the data is not properly prepared
+            #
+            # better to use `.any()` to check if there any rows, and still make
+            # the result worth it
+            if (group.loc[group['scope'] == EScope.S1,'to_calculate'].any() or
+                group.loc[group['scope'] == EScope.S2, 'to_calculate'].any()
             ):
                 # S1 and S2 scores are either calulted or default scores from earlier
                 s1_score = float(group.loc[group['scope'] == EScope.S1, 'temperature_score'].item())


### PR DESCRIPTION
# Introduction

This pull request includes an important change to the `_calculate_s1s2_score` method in the `ITR/temperature_score.py` file. The change improves the robustness of the code by replacing the use of `.item()` with `.any()` to prevent potential `ValueError` exceptions when the DataFrame has more than one row for a particular group.

## Improvements to error handling:

* [`ITR/temperature_score.py`](diffhunk://#diff-82ad98b387bd33a737f716bacc4facd3706c6a7c41c1c26bfabb6b85afb92f7fL793-R801): Modified the `_calculate_s1s2_score` method to use `.any()` instead of `.item()` for checking if there are any rows in the DataFrame, which prevents `ValueError` exceptions when the DataFrame has more than one row for the particular group. This change ensures the code is more robust and can handle improperly prepared data.